### PR TITLE
Migrate to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/karlentwistle/ruby_home-srp.svg?branch=master)](https://travis-ci.org/karlentwistle/ruby_home-srp)
+[![Build Status](https://www.travis-ci.com/karlentwistle/ruby_home-srp.svg?branch=master)](https://www.travis-ci.com/karlentwistle/ruby_home-srp)
 
 # RubyHome-SRP
 


### PR DESCRIPTION
Mostly just wanted to check that the automatic checks are using https://travis-ci.com/ instead of https://travis-ci.org/ which is apparently shutting down in several weeks.